### PR TITLE
feat: Migrate to AWS SDK v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 22
       - run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 22
       - run: npm install
 
       #- run: npm test

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,75 @@
+# Migration Guide: v1.x to v2.0.0
+
+This guide will help you migrate from acady-connector-dynamodb v1.x to v2.0.0.
+
+## Breaking Changes
+
+### AWS SDK v3 Migration
+
+Version 2.0.0 upgrades from AWS SDK v2 to AWS SDK v3. This brings several important changes:
+
+1. **Peer Dependencies**
+   - Remove `aws-sdk` dependency
+   - Add new peer dependencies:
+     ```bash
+     npm install @aws-sdk/client-dynamodb@^3.734.0 @aws-sdk/lib-dynamodb@^3.734.0
+     ```
+
+2. **Configuration Changes**
+   - The configuration object structure remains the same
+   - AWS credentials and region configuration behavior is unchanged
+   - DynamoDB Local configuration remains compatible
+
+### Code Changes Required
+
+No changes to your code should be necessary if you're using the public API. All changes are internal to the library:
+
+- All DynamoDB operations now use the AWS SDK v3 command pattern internally
+- Error handling has been updated to use AWS SDK v3's error structure
+- The DocumentClient has been replaced with DynamoDBDocumentClient
+
+### Example Migration
+
+#### Before (v1.x)
+```json
+{
+  "dependencies": {
+    "acady-connector-dynamodb": "^1.7.1"
+  },
+  "peerDependencies": {
+    "aws-sdk": "^2.821.0"
+  }
+}
+```
+
+#### After (v2.0.0)
+```json
+{
+  "dependencies": {
+    "acady-connector-dynamodb": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.734.0",
+    "@aws-sdk/lib-dynamodb": "^3.734.0"
+  }
+}
+```
+
+## Benefits of Upgrading
+
+1. **Future-Proof**: AWS SDK v2 enters maintenance mode on September 8, 2024
+2. **Performance**: AWS SDK v3 offers improved performance through modular architecture
+3. **Better Types**: Enhanced TypeScript support with AWS SDK v3
+4. **Modern Features**: Access to latest AWS features and improvements
+
+## Troubleshooting
+
+If you encounter any issues during migration:
+
+1. Ensure all peer dependencies are installed correctly
+2. Verify AWS credentials are properly configured
+3. Check for any custom configuration that might need updating
+
+## Need Help?
+
+If you encounter any issues during migration, please [open an issue](https://github.com/acady-io/acady-connector-dynamodb/issues) on our GitHub repository.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,100 @@
+# Acady Connector DynamoDB
+
+A TypeScript library for simplified DynamoDB operations with support for batch operations, table management, and flexible querying.
+
+## Installation
+
+```bash
+npm install acady-connector-dynamodb
+```
+
+### Peer Dependencies
+This package requires the following peer dependencies:
+```bash
+npm install @aws-sdk/client-dynamodb@^3.734.0 @aws-sdk/lib-dynamodb@^3.734.0
+```
+
+## Usage
+
+```typescript
+import { DynamodbEntityConnector } from 'acady-connector-dynamodb';
+
+// Initialize the connector
+const connector = new DynamodbEntityConnector('table-name', 'id');
+
+// Store an item
+await connector.storeItem({
+    id: 'item-1',
+    data: 'example'
+});
+
+// Retrieve an item
+const item = await connector.getItem({ id: 'item-1' });
+
+// Query items
+const items = await connector.query({
+    id: 'item-1'
+}, 'index-name');
+
+// Batch operations
+await connector.batchGet([
+    { id: 'item-1' },
+    { id: 'item-2' }
+]);
+
+// Table management
+await connector.createTable();
+await connector.deleteTable();
+```
+
+## Features
+
+- Full AWS SDK v3 support
+- Automatic table creation
+- Batch operations with configurable batch size
+- Support for DynamoDB Local for testing
+- Comprehensive error handling
+- TypeScript type definitions
+- Table prefix support via `DDB_PREFIX` environment variable
+
+## Configuration
+
+The connector accepts the following configuration options:
+
+```typescript
+const connector = new DynamodbEntityConnector(
+    tableName,    // DynamoDB table name
+    partitionKey, // Partition key name
+    sortKey?,     // Optional sort key name
+    config?       // Optional AWS SDK configuration
+);
+```
+
+### AWS Configuration
+
+The connector will automatically use AWS credentials from environment variables:
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+- `AWS_SESSION_TOKEN` (optional)
+
+For local development, you can use DynamoDB Local by providing the endpoint in the config:
+
+```typescript
+const connector = new DynamodbEntityConnector('table-name', 'id', undefined, {
+    endpoint: 'http://localhost:8000',
+    region: 'local',
+    credentials: {
+        accessKeyId: 'test',
+        secretAccessKey: 'test'
+    }
+});
+```
+
+## Migration
+
+If you're upgrading from v1.x to v2.x, please see the [Migration Guide](./MIGRATION.md) for detailed instructions.
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acady-connector-dynamodb",
-  "version": "0.0.0-dev",
+  "version": "2.0.0",
   "description": "Acady Connector DynamoDB",
   "main": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "@web-academy/core-lib": "^1.0.3"
   },
   "peerDependencies": {
-    "aws-sdk": "^2.821.0"
+    "@aws-sdk/client-dynamodb": "^3.734.0",
+    "@aws-sdk/lib-dynamodb": "^3.734.0"
   },
   "release": {
     "repositoryUrl": "https://github.com/acady-io/acady-connector-dynamodb.git",

--- a/tests/dynamodb-entity-connector.spec.ts
+++ b/tests/dynamodb-entity-connector.spec.ts
@@ -1,14 +1,25 @@
-import {DynamodbEntityConnector} from "../src";
+import { DynamodbEntityConnector } from "../src";
 
 let connector: DynamodbEntityConnector;
 
-beforeAll(() => {
+beforeAll(async () => {
+    // Set up AWS config for testing
+    process.env.AWS_REGION = 'us-east-1';
+    process.env.AWS_ACCESS_KEY_ID = 'test';
+    process.env.AWS_SECRET_ACCESS_KEY = 'test';
+    
     const tableName = 'test-' + Date.now();
-    connector = new DynamodbEntityConnector(tableName, 'id');
-})
+    connector = new DynamodbEntityConnector(tableName, 'id', undefined, {
+        endpoint: 'http://localhost:8000', // DynamoDB Local endpoint
+        region: 'us-east-1',
+        credentials: {
+            accessKeyId: 'test',
+            secretAccessKey: 'test'
+        }
+    });
+});
 
 test('DynamodbEntityConnector: Read and Write', async () => {
-
     const id = 'test-entity-' + Date.now();
     const writeEntity = {
         id,
@@ -22,9 +33,9 @@ test('DynamodbEntityConnector: Read and Write', async () => {
     const readEntity = await connector.getItem({id});
 
     expect(readEntity).toEqual(writeEntity);
-});
+}, 30000);  // Increased timeout for table creation
 
-afterAll(() => {
-    return connector.deleteTable();
+afterAll(async () => {
+    await connector.deleteTable();
 });
 


### PR DESCRIPTION
This PR migrates the DynamoDB connector from AWS SDK v2 to v3.

Key Changes:
- Replace AWS SDK v2 with v3 client and commands
- Update DynamoDB operations to use v3 command pattern
- Update test configuration for local development
- Update peer dependencies to latest AWS SDK v3 version

Note: Tests require DynamoDB Local to be running. Waiting for confirmation on preferred testing approach:
1. Set up DynamoDB Local using Docker
2. Use real AWS DynamoDB instance
3. Use mocks/stubs for testing

Link to Devin run: https://app.devin.ai/sessions/88da831d3a2b4f858bf0e16cf2892e2b